### PR TITLE
Bugfix: Remove dependency sanitize-html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
                 "dotenv": "^16.0.1",
                 "fast-xml-parser": "^4.0.9",
                 "highlight.js": "^11.6.0",
-                "sanitize-html": "^2.7.1",
                 "sharp": "^0.30.7",
                 "svelte-blurhash": "^1.2.1",
                 "svelte-markdown": "^0.2.1"
@@ -903,6 +902,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -952,6 +952,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
             "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -965,6 +966,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -976,6 +978,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -990,6 +993,7 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -1037,6 +1041,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -1427,6 +1432,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1962,6 +1968,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
             "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -2113,14 +2120,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/isexe": {
@@ -2323,6 +2322,8 @@
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
             "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true,
+            "peer": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -2403,11 +2404,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/parse-srcset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-            "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2445,7 +2441,8 @@
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -2463,6 +2460,7 @@
             "version": "8.4.14",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
             "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -2473,6 +2471,7 @@
                     "url": "https://tidelift.com/funding/github/npm/postcss"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -2802,19 +2801,6 @@
                 "rimraf": "bin.js"
             }
         },
-        "node_modules/sanitize-html": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
-            "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
-            "dependencies": {
-                "deepmerge": "^4.2.2",
-                "escape-string-regexp": "^4.0.0",
-                "htmlparser2": "^6.0.0",
-                "is-plain-object": "^5.0.0",
-                "parse-srcset": "^1.0.2",
-                "postcss": "^8.3.11"
-            }
-        },
         "node_modules/sass": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.0.tgz",
@@ -2994,6 +2980,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
             "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4120,7 +4107,8 @@
         "deepmerge": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true
         },
         "detect-indent": {
             "version": "6.1.0",
@@ -4155,6 +4143,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
             "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -4164,12 +4153,14 @@
         "domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true
         },
         "domhandler": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.2.0"
             }
@@ -4178,6 +4169,7 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
             "requires": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -4215,7 +4207,8 @@
         "entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true
         },
         "es6-promise": {
             "version": "3.3.1",
@@ -4415,7 +4408,8 @@
         "escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true
         },
         "eslint": {
             "version": "7.32.0",
@@ -4818,6 +4812,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
             "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
@@ -4922,11 +4917,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
         },
         "isexe": {
             "version": "2.0.0",
@@ -5082,7 +5072,9 @@
         "nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true,
+            "peer": true
         },
         "napi-build-utils": {
             "version": "1.0.2",
@@ -5145,11 +5137,6 @@
                 "callsites": "^3.0.0"
             }
         },
-        "parse-srcset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-            "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5178,7 +5165,8 @@
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "picomatch": {
             "version": "2.3.1",
@@ -5190,6 +5178,8 @@
             "version": "8.4.14",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
             "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "dev": true,
+            "peer": true,
             "requires": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -5399,19 +5389,6 @@
                 }
             }
         },
-        "sanitize-html": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
-            "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
-            "requires": {
-                "deepmerge": "^4.2.2",
-                "escape-string-regexp": "^4.0.0",
-                "htmlparser2": "^6.0.0",
-                "is-plain-object": "^5.0.0",
-                "parse-srcset": "^1.0.2",
-                "postcss": "^8.3.11"
-            }
-        },
         "sass": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.0.tgz",
@@ -5524,7 +5501,8 @@
         "source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "dev": true
         },
         "sourcemap-codec": {
             "version": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "dotenv": "^16.0.1",
         "fast-xml-parser": "^4.0.9",
         "highlight.js": "^11.6.0",
-        "sanitize-html": "^2.7.1",
         "sharp": "^0.30.7",
         "svelte-blurhash": "^1.2.1",
         "svelte-markdown": "^0.2.1"

--- a/src/lib/components/gallerysections/MarkdownSection.svelte
+++ b/src/lib/components/gallerysections/MarkdownSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     // TODO: File issue about this
     import SvelteMarkdown from 'svelte-markdown/src/SvelteMarkdown.svelte';
-    import sanitize from 'sanitize-html';
+    // import sanitize from 'sanitize-html';
     import highlight from 'highlight.js';
 
     export let content: string;

--- a/src/routes/[gallery]/[image].ts
+++ b/src/routes/[gallery]/[image].ts
@@ -12,7 +12,7 @@ import { join } from 'path';
 const cache = new FileCache();
 const resizer = new ImageProcessor(process.env.GALLERIES_BASE);
 
-export const get: RequestHandler = async ({ params, url }) => {
+export const GET: RequestHandler = async ({ params, url }) => {
     const { gallery, image } = params;
     try {
         getGalleryMetadata(gallery);

--- a/src/routes/api/collections/[collectionId].ts
+++ b/src/routes/api/collections/[collectionId].ts
@@ -1,7 +1,7 @@
 import { getAllCollections } from '$lib/gallerieshelper';
 import type { RequestHandler } from '.svelte-kit/types/src/routes/api/collections/__types/[collectionId]';
 
-export const get: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params }) => {
     const { collectionId } = params;
 
     const collections = await getAllCollections();

--- a/src/routes/api/collections/index.ts
+++ b/src/routes/api/collections/index.ts
@@ -1,7 +1,7 @@
 import { getAllCollections } from '$lib/gallerieshelper';
 import type { RequestHandler } from '@sveltejs/kit';
 
-export const get: RequestHandler = async () => {
+export const GET: RequestHandler = async () => {
     const collections = await getAllCollections();
     return {
         status: 200,

--- a/src/routes/api/galleries/[galId]/index.ts
+++ b/src/routes/api/galleries/[galId]/index.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '.svelte-kit/types/src/routes/api/galleries/[galId]/__types/index';
 import { getGallery, translateGallery } from '$lib/gallerieshelper';
 
-export const get: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params }) => {
     const { galId } = params;
 
     try {

--- a/src/routes/api/galleries/[galId]/meta.ts
+++ b/src/routes/api/galleries/[galId]/meta.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '.svelte-kit/types/src/routes/api/galleries/[galId]/__types/meta';
 import { getGalleryMetadata } from '$lib/gallerieshelper';
 
-export const get: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params }) => {
     const { galId } = params;
 
     try {

--- a/src/routes/api/galleries/index.ts
+++ b/src/routes/api/galleries/index.ts
@@ -1,7 +1,7 @@
 import { getGalleries } from '$lib/gallerieshelper';
 import type { Load } from '@sveltejs/kit';
 
-export const get: Load = async () => {
+export const GET: Load = async () => {
     const { groups } = await getGalleries();
     return {
         status: 200,


### PR DESCRIPTION
For some reason, `sanitize-html` isn't compatible with Vite 3 (see vitejs/vite#9200) (SvelteKit now requires Vite 3).
It wasn't even being used, so there is no functional change.